### PR TITLE
add exception when app.ready invoked more than one time in develop mode

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,6 +14,10 @@ var app    = require('spa-app/lib/core'),
     originalKeydownHandler = events.keydown;
 
 
+if ( DEVELOP ) {
+    app.ready = false;
+}
+
 // get instance
 window.core = window.parent.getCoreInstance(window, app);
 
@@ -72,6 +76,11 @@ if ( TARGET === 'android-stb' || TARGET === 'android-app' ) {
  * Show app.
  */
 app.ready = function () {
+    if ( DEVELOP ) {
+        app.ready && throw new Error(__filename + ': app:ready must be called only once');
+        app.ready = true;
+    }
+
     window.core.call('app:ready');
 };
 


### PR DESCRIPTION
added a message for developers who forget about limitations of call `app.ready` only once (pls read our docs, sic!) during the lifetime of the application